### PR TITLE
refactor: migrate from valibot-env to @t3-oss/env-nextjs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@conform-to/react": "^1.7.2",
         "@conform-to/valibot": "^1.7.2",
         "@next/third-parties": "^15.3.4",
+        "@t3-oss/env-nextjs": "^0.13.8",
         "@valibot/i18n": "^1.0.0",
         "@vercel/analytics": "^1.5.0",
         "@yamada-ui/lucide": "^1.10.5",
@@ -22,7 +23,6 @@
         "remeda": "^2.23.0",
         "server-only": "^0.0.1",
         "valibot": "^1.1.0",
-        "valibot-env": "^0.2.1",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.0.4",
@@ -477,6 +477,10 @@
     "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
+
+    "@t3-oss/env-core": ["@t3-oss/env-core@0.13.8", "", { "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0-beta.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-L1inmpzLQyYu4+Q1DyrXsGJYCXbtXjC4cICw1uAKv0ppYPQv656lhZPU91Qd1VS6SO/bou1/q5ufVzBGbNsUpw=="],
+
+    "@t3-oss/env-nextjs": ["@t3-oss/env-nextjs@0.13.8", "", { "dependencies": { "@t3-oss/env-core": "0.13.8" }, "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0-beta.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-QmTLnsdQJ8BiQad2W2nvV6oUpH4oMZMqnFEjhVpzU0h3sI9hn8zb8crjWJ1Amq453mGZs6A4v4ihIeBFDOrLeQ=="],
 
     "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
 
@@ -1507,8 +1511,6 @@
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "valibot": ["valibot@1.1.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw=="],
-
-    "valibot-env": ["valibot-env@0.2.1", "", { "peerDependencies": { "valibot": "^1.0.0-beta.3" } }, "sha512-XuYSwiGuuSeaaMYl+j5qJuvKO+ZcbC24XJoyNXTZjVmsdPmGRrJfpP7LPLZtpBCG/T2RP/eIaQnaE6QCoDiU1Q=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@conform-to/react": "^1.7.2",
     "@conform-to/valibot": "^1.7.2",
     "@next/third-parties": "^15.3.4",
+    "@t3-oss/env-nextjs": "^0.13.8",
     "@valibot/i18n": "^1.0.0",
     "@vercel/analytics": "^1.5.0",
     "@yamada-ui/lucide": "^1.10.5",
@@ -42,8 +43,7 @@
     "react-dom": "^19.1.0",
     "remeda": "^2.23.0",
     "server-only": "^0.0.1",
-    "valibot": "^1.1.0",
-    "valibot-env": "^0.2.1"
+    "valibot": "^1.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.4",

--- a/src/utils/env/index.ts
+++ b/src/utils/env/index.ts
@@ -9,15 +9,16 @@ export const env = createEnv({
     GMAIL_ADDRESS: v.pipe(v.string(), v.email()),
     GMAIL_PASSWORD: v.string(),
   },
-  client: {},
+  client: {
+    NEXT_PUBLIC_GA_ID: v.string(),
+  },
   shared: {
     NODE_ENV: v.union([v.literal("development"), v.literal("production"), v.literal("test")]),
-    GA_ID: v.string(),
   },
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
     GMAIL_ADDRESS: process.env.GMAIL_ADDRESS,
     GMAIL_PASSWORD: process.env.GMAIL_PASSWORD,
-    GA_ID: process.env.GA_ID,
+    NEXT_PUBLIC_GA_ID: process.env.NEXT_PUBLIC_GA_ID,
   },
 });

--- a/src/utils/env/index.ts
+++ b/src/utils/env/index.ts
@@ -1,26 +1,23 @@
+import { createEnv } from "@t3-oss/env-nextjs";
 import * as v from "valibot";
-import { createEnv } from "valibot-env/nextjs";
 
 /**
  * 検証済み環境変数
- * @see https://zenn.dev/chot/articles/abount-valibot-env
  */
 export const env = createEnv({
-  schema: {
-    public: {},
-    private: {
-      GMAIL_ADDRESS: v.pipe(v.string(), v.email()),
-      GMAIL_PASSWORD: v.string(),
-    },
-    shared: {
-      NODE_ENV: v.union([v.literal("development"), v.literal("production"), v.literal("test")]),
-      GA_ID: v.string(),
-    },
+  server: {
+    GMAIL_ADDRESS: v.pipe(v.string(), v.email()),
+    GMAIL_PASSWORD: v.string(),
   },
-  values: {
+  client: {},
+  shared: {
+    NODE_ENV: v.union([v.literal("development"), v.literal("production"), v.literal("test")]),
+    GA_ID: v.string(),
+  },
+  runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
     GMAIL_ADDRESS: process.env.GMAIL_ADDRESS,
     GMAIL_PASSWORD: process.env.GMAIL_PASSWORD,
-    GA_ID: process.env.NEXT_PUBLIC_GA_ID,
+    GA_ID: process.env.GA_ID,
   },
 });

--- a/src/views/csv/index.tsx
+++ b/src/views/csv/index.tsx
@@ -1,7 +1,7 @@
 import { ArrowDownIcon } from "@yamada-ui/lucide";
 import { Markdown } from "@yamada-ui/markdown";
 import { Box, Container, Heading, HStack } from "@yamada-ui/react";
-import { type Column, Table, TableProps } from "@yamada-ui/table";
+import { type Column, Table, type TableProps } from "@yamada-ui/table";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import papa from "papaparse";

--- a/src/views/layout/index.tsx
+++ b/src/views/layout/index.tsx
@@ -13,7 +13,7 @@ export const LayoutPage: FC<{ children: ReactNode }> = ({ children }) => {
   return (
     <Providers>
       <Analytics />
-      <GoogleAnalytics gaId={env.GA_ID} />
+      <GoogleAnalytics gaId={env.NEXT_PUBLIC_GA_ID} />
       <Header />
       <Separator />
       <Navigation />


### PR DESCRIPTION
## Summary
- Replace valibot-env with @t3-oss/env-nextjs for environment variable validation
- Update environment configuration structure to use t3-env format
- Maintain valibot for validation schemas while using t3-env for environment management

## Test plan
- [x] Build completes successfully
- [x] Environment variables are properly validated
- [x] Application starts without errors

🤖 Generated with [Claude Code](https://claude.ai/code)